### PR TITLE
Expose a few functions needed by authenticator-rs and bump to v0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nss-gk-api"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Martin Thomson <mt@lowentropy.net>", "Andy Leiserson <aleiserson@mozilla.com>", "John M. Schanck <jschanck@mozilla.com>"]
 edition = "2018"
 rust-version = "1.57.0"

--- a/bindings/bindings.toml
+++ b/bindings/bindings.toml
@@ -184,6 +184,8 @@ functions = [
     "PK11_PubDeriveWithKDF",
     "PK11_ReadRawAttribute",
     "PK11_ReferenceSymKey",
+    "PK11_SignWithMechanism",
+    "PK11_VerifyWithMechanism",
     "SECKEY_CopyPrivateKey",
     "SECKEY_CopyPublicKey",
     "SECKEY_DecodeDERSubjectPublicKeyInfo",

--- a/bindings/bindings.toml
+++ b/bindings/bindings.toml
@@ -165,6 +165,7 @@ functions = [
     "PK11_DigestOp",
     "PK11_DigestFinal",
     "PK11_Encrypt",
+    "PK11_ExportDERPrivateKeyInfo",
     "PK11_ExtractKeyValue",
     "PK11_FindCertFromNickname",
     "PK11_FindKeyByAnyCert",
@@ -186,6 +187,7 @@ functions = [
     "PK11_ReferenceSymKey",
     "PK11_SignWithMechanism",
     "PK11_VerifyWithMechanism",
+    "PK11_WrapPrivKey",
     "SECKEY_CopyPrivateKey",
     "SECKEY_CopyPublicKey",
     "SECKEY_DecodeDERSubjectPublicKeyInfo",
@@ -214,6 +216,7 @@ opaque = [
 ]
 variables = [
     "AES_BLOCK_SIZE",
+    "PK11_ATTR_EXTRACTABLE",
     "PK11_ATTR_INSENSITIVE",
     "PK11_ATTR_PRIVATE",
     "PK11_ATTR_PUBLIC",


### PR DESCRIPTION
Authenticator-rs needs to create and verify ECDSA P256 signatures. The test token I'm currently implementing saves raw private key material using `PK11_ExportDERPrivateKeyInfo`, but in the future we'll want to support wrapping private keys so I added `PK11_WrapPrivKey` as well.

One quirk: `PK11_ExportDERPrivateKeyInfo` returns an NSS-allocated `SECItem` (instead of just allocating the `data`). This crate didn't have a nice way to handle this, so I borrowed `Item` from the ohttp crate. I'm calling it `ScopedSECItem` here, as I think that matches the C++ analogue, but I'm happy to change it if we want consistency with ohttp.