### PR TITLE
Allowing dead_code for not used Path in NssLoaded

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ pub const PR_TRUE: PRBool = prtypes::PR_TRUE as PRBool;
 enum NssLoaded {
     External,
     NoDb,
+    #[allow(dead_code)]
     Db(Box<Path>),
 }
 


### PR DESCRIPTION
cargo (1.85.0) does not allow to build the project because Path is never read. 

So, we can remove the Box<Path> and leave only Db() or to allow the unused path. 